### PR TITLE
Changed obs dtype to float32 (from float64) to match the obs space definition

### DIFF
--- a/myosuite/envs/obs_vec_dict.py
+++ b/myosuite/envs/obs_vec_dict.py
@@ -80,7 +80,7 @@ class ObsVecDict():
 
         obs_list = [np.zeros(0)]
         for key in self.ordered_obs_keys:
-            obs_list.append(obs_dict[key].ravel())
+            obs_list.append(obs_dict[key].ravel())  # ravel helps with images
         obsvec = np.concatenate(obs_list, dtype=np.float32)
 
         # cache

--- a/myosuite/envs/obs_vec_dict.py
+++ b/myosuite/envs/obs_vec_dict.py
@@ -78,10 +78,10 @@ class ObsVecDict():
         if not self.initialized:
             self.initialize(obs_dict, ordered_obs_keys)
 
-        # recover vec
-        obsvec = np.zeros(0)
+        obs_list = [np.zeros(0)]
         for key in self.ordered_obs_keys:
-            obsvec = np.concatenate([obsvec, obs_dict[key].ravel()]) # ravel helps with images
+            obs_list.append(obs_dict[key].ravel())
+        obsvec = np.concatenate(obs_list, dtype=np.float32)
 
         # cache
         t = obs_dict['time']


### PR DESCRIPTION
Hello,

The [observation space was defined as float32](https://github.com/MyoHub/myosuite/blob/main/myosuite/envs/env_base.py#L139), but the obs was returned in float64, resulting in these warnings:
```
/home/kywch/myo-trainer/.venv/lib/python3.11/site-packages/gymnasium/utils/passive_env_checker.py:135: UserWarning: WARN: The obs returned by the `reset()` method was expecting numpy array dtype to be float32, actual type: float64
  logger.warn(
/home/kywch/myo-trainer/.venv/lib/python3.11/site-packages/gymnasium/utils/passive_env_checker.py:159: UserWarning: WARN: The obs returned by the `reset()` method is not within the observation space.
  logger.warn(f"{pre} is not within the observation space.")
```

I've fixed the obs to have float32 and reduced the number of concatenations. The warning is gone. It has also passed the tests and gives similar results.

Please let me know if you need anything. Thanks!

