### PR TITLE
Basic arm reaching environment created, myoArmReachRandom-v0

### DIFF
--- a/myosuite/envs/myo/assets/arm/myoarm_reach.xml
+++ b/myosuite/envs/myo/assets/arm/myoarm_reach.xml
@@ -1,0 +1,30 @@
+<mujoco model="MyoArm_v0.01">
+<!-- =================================================
+    Copyright 2020 Vikash Kumar, Vittorio Caggiano, Guillaume Durandau
+    Model   :: Myo Hand (MuJoCoV2.0)
+    Author  :: Vikash Kumar (vikashplus@gmail.com), Vittorio Caggiano, Huawei Wang
+    source  :: https://github.com/vikashplus
+    License :: Under Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+====================================================== -->
+
+    <include file="../../../../simhive/myo_sim/arm/assets/myoarm_assets.xml"/>
+    <include file="../../../../simhive/myo_sim/scene/myosuite_scene.xml"/>
+    <compiler meshdir='../../../../simhive/myo_sim/' texturedir='../../../../simhive/myo_sim/'/>
+
+    <asset>
+        <mesh file="../myo_sim/meshes/human_lowpoly_norighthand.stl" name="body_norighthand"/>
+    </asset>
+
+    <worldbody>
+
+        <!-- ======= MyoArm ======= -->
+        <geom name="body" type="mesh" mesh="body_norighthand" euler="0 0 3.14" contype="0" conaffinity="0"/>
+        <body name="full_body" pos="-.025 0.1 1.40">
+            <include file="../../../../simhive/myo_sim/arm/assets/myoarm_body.xml"/>
+        </body>
+
+        <site name="S_grasp_target" pos="0 0 0.002" rgba="0 1 0 .3" size="0.02"/>
+
+    </worldbody>
+
+</mujoco>

--- a/myosuite/envs/myo/myobase/__init__.py
+++ b/myosuite/envs/myo/myobase/__init__.py
@@ -518,3 +518,17 @@ register_env_with_variants(id='myoHandReorientOOD-v0',
                 'frame_skip': 5,
             }
     )
+
+# Arm Reaching ==============================
+register_env_with_variants(id='myoArmReachRandom-v0',
+        entry_point='myosuite.envs.myo.myobase.reach_v0:ReachEnvV0',
+        max_episode_steps=150,
+        kwargs={
+            'model_path': curr_dir+'/../assets/arm/myoarm_reach.xml',
+            'target_reach_range': {
+                'S_grasp': ((-0.2-0.2, -0.2-0.15, 1.2-0.2), (-0.2+0.2, -0.2+0.15, 1.2+0.2)),
+                },
+            'normalize_act': True,
+            'far_th': 0.025
+            }
+    )


### PR DESCRIPTION
I have created a basic environment for reaching to random targets in space with the MyoSuite arm.

- I created a new myoarm_reach.xml file by modifying the existing myoarm_relocate.xml file (I removed the object, table and bin and added a target as a site element).
- I used the ReachEnvV0 environment class as the entry point for the environment.
- The palm position ('S_grasp') is the part of the arm that needs to reach the target.
- I registered a new environment, ''myoArmReachRandom-v0', in /myosuite/myosuite/envs/myo/myobase/__init__.py.
- The target_reach_range has been set to encourage reasonable exploration of the 3D space. 
- **Let me know if you have an established methodology for determining the ideal environment parameters (e.g. target_reach_range, max_episode_steps, far_th).** I'd love to optimise these so that the environment can be made available to the community (a couple of people have already messaged me in the MyoSuite slack workspace to ask if they can access the environment).