### PR TITLE
import myosuite before sb3 to ensure envs are registered

### DIFF
--- a/myosuite/agents/sb3_job_script.py
+++ b/myosuite/agents/sb3_job_script.py
@@ -10,6 +10,7 @@ This is a job script for running SB3 on myosuite tasks.
 import os
 import json
 import time as timer
+import myosuite
 from stable_baselines3 import PPO, SAC
 from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.env_util import make_vec_env


### PR DESCRIPTION
For some SLURM/HPC setups, the registered MyoSuite envs are not recognised correctly when using Hydra.
In particular, the job terminates with error "gymnasium.error.NameNotFound: Environment ... doesn't exist".

This can be fixed by importing myosuite in the sb3_job_script.py _before_ sb3 (which loads gymnasium) is imported.

I have not tested whether the same issue occurs when using torchrl_job_script.py, but a similar fix may be required.