### PR TITLE
BUGFIX: mc25-pingpang-pad-contact

### DIFF
--- a/myosuite/envs/myo/myochallenge/pingpong_v0.py
+++ b/myosuite/envs/myo/myochallenge/pingpong_v0.py
@@ -290,7 +290,7 @@ class IdInfo:
 
         self.ball_bid = model.body("pingpong").id
         self.own_half_gid = model.geom("coll_own_half").id
-        self.paddle_gid = model.geom("ping_pong_paddle").id
+        self.paddle_gid = model.geom("pad").id 
         self.opponent_half_gid = model.geom("coll_opponent_half").id
         self.ground_gid = model.geom("ground").id
         self.net_gid = model.geom("coll_net").id


### PR DESCRIPTION
Fixed an issue where paddle-ball collisions were not being correctly detected in the PingPong environment. The bug caused paddle contacts to be incorrectly classified as ENV contacts instead of PADDLE contacts in the observation vector.